### PR TITLE
車両のデータ構造を変更し車種名を出力時に表示

### DIFF
--- a/car.gs
+++ b/car.gs
@@ -1,6 +1,7 @@
 class Car {
-  constructor(capacity, origin){
-    this.capacity = capacity;
+  constructor(carType, origin){
+    this.carType = carType;
+    this.capacity = carType["capacity"];
     this.origin = origin;
     this.members = [];
     this.waypoints = [];
@@ -47,7 +48,7 @@ class Car {
         name += point;
       }
     }
-    name += "配車";
+    name += "配車[" + this.carType["name"] + "]";
     return name;
   }
 };

--- a/carOptimizer.gs
+++ b/carOptimizer.gs
@@ -8,15 +8,13 @@ class CarOptimizer {
 
     //rentfeeTableの初期化
     for(const car of cars){
-      this.rentfeeTable[car["capacity"]] = car["cost"];
-    }
-    let rentfee = Infinity;
-    for(let i = 8; i > 0; i--){
-      if(this.rentfeeTable[i] != undefined){
-        rentfee = this.rentfeeTable[i];
-      }else{
-        this.rentfeeTable[i] = rentfee;
-      }
+      for(let i = car["capacity"]; i > 0; i--){
+        if(this.rentfeeTable[i] == undefined || this.rentfeeTable[i]["cost"] > car["cost"]){
+          this.rentfeeTable[i] = car;
+        }else{
+          break;
+        }
+      }      
     }
   }
 
@@ -28,15 +26,15 @@ class CarOptimizer {
       if(n > 8){
         this.dpTable[0][n] = {"carCombi": [], "rentfee": Infinity};
       }else{
-        this.dpTable[0][n] = {"carCombi": [n], "rentfee": this.rentfeeTable[n]};
+        this.dpTable[0][n] = {"carCombi": [this.rentfeeTable[n]], "rentfee": this.rentfeeTable[n]["cost"]};
       }      
     }else{
       this.dpTable[k][n] = {"carCombi": [], "rentfee": Infinity};
       for(let i = 1; i < n; i++){
-        if(this.rentfeeTable[i] + this.dpTable[k-1][n-i]["rentfee"] < this.dpTable[k][n]["rentfee"]){
+        if(this.rentfeeTable[i]["cost"] + this.dpTable[k-1][n-i]["rentfee"] < this.dpTable[k][n]["rentfee"]){
           this.dpTable[k][n]["carCombi"] = this.dpTable[k-1][n-i]["carCombi"].slice();
-          this.dpTable[k][n]["carCombi"].push(i);
-          this.dpTable[k][n]["rentfee"] = this.dpTable[k-1][n-i]["rentfee"] + this.rentfeeTable[i];
+          this.dpTable[k][n]["carCombi"].push(this.rentfeeTable[i]);
+          this.dpTable[k][n]["rentfee"] = this.dpTable[k-1][n-i]["rentfee"] + this.rentfeeTable[i]["cost"];
         }
       }
     }

--- a/carOptimizer.gs
+++ b/carOptimizer.gs
@@ -1,9 +1,23 @@
 class CarOptimizer {
-  constructor(table){
-    this.rentfeeTable = table;
+  constructor(cars, fixedCost){
+    this.rentfeeTable = [];
+    this.fixedCost = fixedCost;
     this.maxMember = 0;
     this.maxRentee = 0;
     this.dpTable = [];
+
+    //rentfeeTableの初期化
+    for(const car of cars){
+      this.rentfeeTable[car["capacity"]] = car["cost"];
+    }
+    let rentfee = Infinity;
+    for(let i = 8; i > 0; i--){
+      if(this.rentfeeTable[i] != undefined){
+        rentfee = this.rentfeeTable[i];
+      }else{
+        this.rentfeeTable[i] = rentfee;
+      }
+    }
   }
 
   fillTableCell(k, n){
@@ -41,8 +55,8 @@ class CarOptimizer {
     }
     let carCombi, rentfee;
     for(let k = 0; k < numRentee; k++){
-      let fixedCost = this.rentfeeTable[0] * (k + 1);
-      if(k == 0 || this.dpTable[k][numMember]["rentfee"] + fixedCost < rentfee){
+      let totalFixedCost = this.fixedCost * (k + 1);
+      if(k == 0 || this.dpTable[k][numMember]["rentfee"] + totalFixedCost < rentfee){
         carCombi = this.dpTable[k][numMember]["carCombi"].slice();
         rentfee = this.dpTable[k][numMember]["rentfee"];
       }

--- a/haishaGenerator.gs
+++ b/haishaGenerator.gs
@@ -11,20 +11,7 @@ function vehicleManager(configData, inputData) {
   const version = "v2.0-alpha.1"
 
   //rentfeeTableにレンタ価格設定
-  let rentfeeTable = [];
-  rentfeeTable[0] = configData["fixedCost"];
-  for(const car of configData["cars"]){
-    rentfeeTable[car["capacity"]] = car["cost"];
-  }
-  let rentfee = Infinity;
-  for(let i = 8; i > 0; i--){
-    if(rentfeeTable[i] != undefined){
-      rentfee = rentfeeTable[i];
-    }else{
-      rentfeeTable[i] = rentfee;
-    }
-  }
-  carOptimizers[0] = new CarOptimizer(rentfeeTable);
+  carOptimizers[0] = new CarOptimizer(configData["cars"], configData["fixedCost"]);
 
   //pointsに乗車地設定
   for(const point of configData["points"]){

--- a/point.gs
+++ b/point.gs
@@ -79,10 +79,8 @@ class Point {
   }
 
   setCars(combi){
-    let capacity;
-    for(capacity of combi){
-      let car = new Car(capacity, this.ptName);
-      this.cars.push(car);
+    for(const carType of combi){
+      this.cars.push(new Car(carType, this.ptName));
     }
   }
 


### PR DESCRIPTION
### 目的
従来のCarインスタンスは割り当て人数の情報しか持っておらず、車種の情報を保持していないことから、出力時に車種の情報を表示できず、また実装中の局所探索法の評価値計算にも支障が生じていた。
Carインスタンスで車種の詳細情報を保持することで、これらの問題を解決した。
※車種の詳細情報：車種名、定員、費用

### 関連issue

- #26 

### 変更点

- CarOptimizerインスタンスで車種の詳細情報を保持し、出力は定員の配列から車種データの配列に変更。
- Carインスタンスで車種の詳細情報を保持。
- 配車名を「〇〇配車[車種名]」のような形式に変更。