### PR TITLE
局所探索法の導入

### DIFF
--- a/car.gs
+++ b/car.gs
@@ -90,6 +90,9 @@ class Car {
   }
 
   evaluate(){
-    return 0;
+    const waypointScore = this.getWaypoints().length * 1000;
+    const expenceScore = 0;
+    const totalScore = waypointScore + expenceScore;
+    return totalScore;
   }
 };

--- a/car.gs
+++ b/car.gs
@@ -33,12 +33,47 @@ class Car {
     member.setAssigned();
   }
 
+  clone(){
+    let car = new Car(this.capacity, this.origin);
+    for(const member of this.getMembers()){
+      car.addMember(member);
+    }
+    return car;
+  }
+
+  deleteMembersByPoint(point){
+    const members = this.members[point];
+    delete this.members[point];
+    return members;
+  }
+
+  getWaypoints(){
+    let waypoints = [];
+    for(const point in this.members){
+      if(point != this.origin){
+        waypoints.push(point);
+      }
+    }
+    return waypoints;
+  }
+
+  merge(car){
+    const members = car.getMembers();
+    for(const member of members){
+      this.addMember(member);
+    }
+  }
+
   isFull(){
     if(this.getMembers().length < this.capacity){
       return false;
     }else{
       return true;
     }
+  }
+
+  getNumMember(){
+    return this.getMembers().length;
   }
 
   getNumVacant(){
@@ -52,5 +87,9 @@ class Car {
     }
     name += "配車";
     return name;
+  }
+
+  evaluate(){
+    return 0;
   }
 };

--- a/car.gs
+++ b/car.gs
@@ -35,7 +35,7 @@ class Car {
   }
 
   clone(){
-    let car = new Car(this.capacity, this.origin);
+    let car = new Car(this.carType, this.origin);
     for(const member of this.getMembers()){
       car.addMember(member);
     }
@@ -56,6 +56,10 @@ class Car {
       }
     }
     return waypoints;
+  }
+
+  updateCarType(){
+    this.carType = points[this.origin].getCarType(this.getNumMember());
   }
 
   merge(car){
@@ -92,7 +96,7 @@ class Car {
 
   evaluate(){
     const waypointScore = this.getWaypoints().length * 1000;
-    const expenceScore = 0;
+    const expenceScore = this.carType["cost"];
     const totalScore = waypointScore + expenceScore;
     return totalScore;
   }

--- a/car.gs
+++ b/car.gs
@@ -95,9 +95,32 @@ class Car {
   }
 
   evaluate(){
+    const costPerDistance = (16 + 20) * 2;
+
+    //経路を確定
+    let waypoints = this.getWaypoints().slice();
+    let crrPoint = this.origin;
+    let totalDistance = 0;
+    while(waypoints.length > 0){
+      let crrDistance = Infinity;
+      let crrWaypoint;
+      for(const point of waypoints){
+        const newDistance = points[crrPoint].getDistance(point);
+        if(newDistance < crrDistance){
+          crrDistance = newDistance;
+          crrWaypoint = point;
+        }
+        totalDistance += crrDistance;
+        waypoints.splice(waypoints.indexOf(crrWaypoint), 1);
+        crrPoint = crrWaypoint;
+      }
+    }
+
+    //評価値を導出
+    const durationScore = totalDistance * this.getNumMember() * 500 / 40;
     const waypointScore = this.getWaypoints().length * 1000;
-    const expenceScore = this.carType["cost"];
-    const totalScore = waypointScore + expenceScore;
+    const expenceScore = this.carType["cost"] + totalDistance * costPerDistance;
+    const totalScore = durationScore + waypointScore + expenceScore;
     return totalScore;
   }
 };

--- a/car.gs
+++ b/car.gs
@@ -2,12 +2,21 @@ class Car {
   constructor(capacity, origin){
     this.capacity = capacity;
     this.origin = origin;
-    this.members = [];
-    this.waypoints = [];
+    this.members = {};
+  }
+
+  getMembers(){
+    let members = [];
+    for(const point in this.members){
+      if(this.members[point].length > 0){
+        members = members.concat(this.members[point]);
+      }
+    }
+    return members;
   }
 
   hasRentee(){
-    if(this.members.length == 0){
+    if(this.getMembers().length == 0){
       return false;
     }else{
       return true;
@@ -15,17 +24,17 @@ class Car {
   }
 
   addMember(member){
-    let point = member.getBoardPt();
-    if(point != this.origin){
-      this.members.push(member);
+    const point = member.getBoardPt();
+    if(point in this.members){
+      this.members[point].push(member);
     }else{
-      this.members.splice(1, 0, member);
+      this.members[point] = [member];
     }
     member.setAssigned();
   }
 
   isFull(){
-    if(this.members.length < this.capacity){
+    if(this.getMembers().length < this.capacity){
       return false;
     }else{
       return true;
@@ -33,19 +42,13 @@ class Car {
   }
 
   getNumVacant(){
-    return this.capacity - this.members.length;
+    return this.capacity - this.getMembers().length;
   }
 
   getName(){
-    let member;
     let name = "";
-    let waypoints = [];
-    for(member of this.members){
-      let point = member.getBoardPt();
-      if(waypoints.includes(point) == false){
-        waypoints.push(point);
-        name += point;
-      }
+    for(const point in this.members){
+      name += point;
     }
     name += "配車";
     return name;

--- a/carOptimizer.gs
+++ b/carOptimizer.gs
@@ -31,6 +31,7 @@ class CarOptimizer {
     }else{
       this.dpTable[k][n] = {"carCombi": [], "rentfee": Infinity};
       for(let i = 1; i < n; i++){
+        if(i > 8) break;
         if(this.rentfeeTable[i]["cost"] + this.dpTable[k-1][n-i]["rentfee"] < this.dpTable[k][n]["rentfee"]){
           this.dpTable[k][n]["carCombi"] = this.dpTable[k-1][n-i]["carCombi"].slice();
           this.dpTable[k][n]["carCombi"].push(this.rentfeeTable[i]);
@@ -62,5 +63,9 @@ class CarOptimizer {
     this.maxMember = numMember;
     this.maxRentee = numRentee;
     return carCombi;
+  }
+
+  getCarType(numMember){
+    return this.rentfeeTable[numMember];
   }
 }

--- a/haishaGenerator.gs
+++ b/haishaGenerator.gs
@@ -91,6 +91,8 @@ function vehicleManager(configData, inputData) {
           for(const member of members){
             newY.addMember(member);
           }
+          newX.updateCarType();
+          newY.updateCarType();
           const newscore = newX.evaluate() + newY.evaluate();
           if(crrscore - newscore > neighbor["score"]){
             neighbor["old"] = [x, y];
@@ -103,6 +105,7 @@ function vehicleManager(configData, inputData) {
         if(cars[y].getNumMember() + cars[x].getNumMember() <= 8){
           let newY = cars[y].clone();
           newY.merge(cars[x]);
+          newY.updateCarType();
           const newscore = newY.evaluate();
           if(crrscore - newscore > neighbor["score"]){
             neighbor["old"] = [x, y];

--- a/haishaGenerator.gs
+++ b/haishaGenerator.gs
@@ -1,5 +1,4 @@
 let points = {};
-let distTable = [];
 let carOptimizers = [];
 let numAssigned = 0;    //割り当て済み人数
 
@@ -8,6 +7,7 @@ let totalRentee = 0;      //借受可能総人数
 
 
 function vehicleManager(configData, inputData) {
+  let distanceTable = [];
   let cars = [];
   const version = "v2.0-alpha.1"
 
@@ -19,20 +19,13 @@ function vehicleManager(configData, inputData) {
     points[point["name"]] = new Point(point["name"], point["lat"], point["lon"]);
   }
 
-  //乗車地間の距離計算
-  for(pt1 in points){
-    for(pt2 in points){
-      if(pt1 != pt2){
-        var dist1 = Math.pow(points[pt1].getLat() - points[pt2].getLat(), 2);
-        var dist2 = Math.pow(points[pt1].getLon() - points[pt2].getLon(), 2);
-        var dist = dist1 + dist2;
-        distTable.push({"loc1": pt1, "loc2": pt2, "dist": dist});
-      }
-    }
+  //乗車地間の距離表作成
+  for(const point in points){
+    distanceTable = distanceTable.concat(points[point].initDistanceTable());
   }
-  distTable.sort(function(a, b){
-    if(a["dist"] < b["dist"]) return -1;
-    if(a["dist"] > b["dist"]) return 1;
+  distanceTable.sort(function(a, b){
+    if(a["distance"] < b["distance"]) return -1;
+    if(a["distance"] > b["distance"]) return 1;
     return 0;
   });
 
@@ -57,11 +50,10 @@ function vehicleManager(configData, inputData) {
   }
 
   //経由地割り当て
-  var locPair;
-  for(locPair of distTable){
+  for(const locPair of distanceTable){
     if(numAssigned == totalMember) break;
-    var childPt = locPair["loc1"];
-    var parentPt = locPair["loc2"];
+    const parentPt = locPair["start"];
+    const childPt = locPair["goal"];
     if(points[childPt].getRemainMember() > 0){
       points[parentPt].addChildPtMember(childPt);
     }

--- a/haishaGenerator.gs
+++ b/haishaGenerator.gs
@@ -117,7 +117,7 @@ function vehicleManager(configData, inputData) {
       for (let i = 0; i < cars.length; i++){
         if (cars[i] === undefined){
           cars.splice(i, 1);  // 削除
-          if (i > 0) i--;
+          i--;
         }
       }
       for(const car of neighbor["new"]){

--- a/haishaGenerator.gs
+++ b/haishaGenerator.gs
@@ -8,6 +8,7 @@ let totalRentee = 0;      //借受可能総人数
 
 
 function vehicleManager(configData, inputData) {
+  let cars = [];
   const version = "v2.0-alpha.1"
 
   //rentfeeTableにレンタ価格設定
@@ -81,21 +82,23 @@ function vehicleManager(configData, inputData) {
 
   //車両の決定、メンバー割り当て
   for(const point in points){
-    points[point].assignMembers();
+    if(points[point].getNumMember() > 0){
+      cars = cars.concat(points[point].assignMembers());
+    }
   }
 
   //JSON書き出し
   let json = {"fileVersion": version, "status": "SUCCESS", "cars": []};
-  for(const point in points){
-    for(const car of points[point].cars){
-      const name = car.getName();
-      let members = [];
-      for(const member of car.members){
-        members.push({"name": member["name"]});
-      }
-      json["cars"].push({"name": name, "members": members})
+  //for(const point in points){
+  for(const car of cars){
+    const name = car.getName();
+    let members = [];
+    for(const member of car.members){
+      members.push({"name": member["name"]});
     }
+    json["cars"].push({"name": name, "members": members})
   }
+  //}
 
   return json;
 }

--- a/haishaGenerator.gs
+++ b/haishaGenerator.gs
@@ -105,10 +105,10 @@ function vehicleManager(configData, inputData) {
             newY.addMember(member);
           }
           const newscore = newX.evaluate() + newY.evaluate();
-          if(newscore - crrscore > neighbor["score"]){
+          if(crrscore - newscore > neighbor["score"]){
             neighbor["old"] = [x, y];
             neighbor["new"] = [newX, newY];
-            neighbor["score"] = newscore - crrscore;
+            neighbor["score"] = crrscore - newscore;
           }
         }
 
@@ -117,10 +117,10 @@ function vehicleManager(configData, inputData) {
           let newY = cars[y].clone();
           newY.merge(cars[x]);
           const newscore = newY.evaluate();
-          if(newscore - crrscore > neighbor["score"]){
+          if(crrscore - newscore > neighbor["score"]){
             neighbor["old"] = [x, y];
             neighbor["new"] = [newY];
-            neighbor["score"] = newscore - crrscore;
+            neighbor["score"] = crrscore - newscore;
           }
         }
       }

--- a/haishaGenerator.gs
+++ b/haishaGenerator.gs
@@ -108,6 +108,7 @@ function vehicleManager(configData, inputData) {
           if(newscore - crrscore > neighbor["score"]){
             neighbor["old"] = [x, y];
             neighbor["new"] = [newX, newY];
+            neighbor["score"] = newscore - crrscore;
           }
         }
 
@@ -119,6 +120,7 @@ function vehicleManager(configData, inputData) {
           if(newscore - crrscore > neighbor["score"]){
             neighbor["old"] = [x, y];
             neighbor["new"] = [newY];
+            neighbor["score"] = newscore - crrscore;
           }
         }
       }
@@ -127,7 +129,14 @@ function vehicleManager(configData, inputData) {
     //解が改善したなら解を更新、そうでなければ終了
     if(neighbor["score"] > 0){
       for(const index of neighbor["old"]){
-        cars.splice(index, 1);
+        //cars.splice(index, 1);
+        delete cars[index];
+      }
+      for (let i = 0; i < cars.length; i++){
+        if (cars[i] === undefined){
+          cars.splice(i, 1);  // 削除
+          if (i > 0) i--;
+        }
       }
       for(const car of neighbor["new"]){
         cars.push(car);

--- a/haishaGenerator.gs
+++ b/haishaGenerator.gs
@@ -89,16 +89,14 @@ function vehicleManager(configData, inputData) {
 
   //JSON書き出し
   let json = {"fileVersion": version, "status": "SUCCESS", "cars": []};
-  //for(const point in points){
   for(const car of cars){
     const name = car.getName();
     let members = [];
-    for(const member of car.members){
+    for(const member of car.getMembers()){
       members.push({"name": member["name"]});
     }
     json["cars"].push({"name": name, "members": members})
   }
-  //}
 
   return json;
 }

--- a/point.gs
+++ b/point.gs
@@ -168,5 +168,7 @@ class Point {
         }      
       }
     }
+
+    return this.cars;
   }
 };

--- a/point.gs
+++ b/point.gs
@@ -40,6 +40,13 @@ class Point {
     return this.distanceTable;
   }
 
+  getDistance(point){
+    for(const pointPair of this.distanceTable){
+      if(pointPair["goal"] != point) continue;
+      return pointPair["distance"];
+    }
+  }
+
   registerMember(member){
     totalMember++;
     this.members.push(member);

--- a/point.gs
+++ b/point.gs
@@ -6,6 +6,7 @@ class Point {
     this.lon = lon;
     this.cars = [];
     this.carOptimizer = carOptimizers[0];
+    this.distanceTable = [];
   }
 
   getLat(){
@@ -14,6 +15,29 @@ class Point {
 
   getLon(){
     return this.lon;
+  }
+
+  initDistanceTable(){
+    const R = Math.PI / 180;
+    const convertRatio = 1.3035
+    for(const point in points){
+      if(point == this.ptName) continue;
+      const lat1 = this.lat * R;
+      const lon1 = this.lon * R;
+      const lat2 = points[point].getLat() * R;
+      const lon2 = points[point].getLon() * R;
+      const distance = 6371 * Math.acos(Math.cos(lat1) * Math.cos(lat2) * Math.cos(lon2 - lon1) + Math.sin(lat1) * Math.sin(lat2));
+      this.distanceTable.push({"start": this.ptName, "goal": point, "distance": distance * convertRatio});
+    }
+
+    //近い順に並べ替え
+    this.distanceTable.sort(function(a, b){
+      if(a["dist"] < b["dist"]) return -1;
+      if(a["dist"] > b["dist"]) return 1;
+      return 0;
+    });
+
+    return this.distanceTable;
   }
 
   registerMember(member){

--- a/point.gs
+++ b/point.gs
@@ -84,6 +84,10 @@ class Point {
     }
   }
 
+  getCarType(numMember){
+    return this.carOptimizer.getCarType(numMember);
+  }
+
   getChildPts(){
     let member;
     let childPts = [];


### PR DESCRIPTION
### 目的
探索アルゴリズムの1つである局所探索法を導入することで、発見的手法による解の精度限界を超え、よりよい解を導出できるようにする。

### 関連issue

- #25 

### 変更点

- 生成されたCarインスタンスはhaishaGenerator側で保持される。
- 局所探索法を採用、近傍解の生成は次の2パターン。
  - 任意の2つの配車について、一方の配車の1つの経由地のメンバーをもう一方の配車に移動。
  - 任意の2つの配車について、一方をもう一方に統合可能なら統合。
- 生成された解は、以下の尺度の和で評価される。
  - 【時間的評価】始点からの所要時間(h)  * 配車の乗車人数 * 500(yen)
  - 【費用的評価】レンタ代 + 始点からの距離 * (燃料代単価(16yen) + 高速代単価(20yen)) * 2
  - 【経由地数評価】経由地の数 * 1000(yen)
  - 距離、所要時間は直線距離に係数を掛けて導出
- 直線距離の求め方を2次元平面近似から球面上の近似に変更し精度を向上。